### PR TITLE
feat: Redesign Group Info page

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -747,7 +747,13 @@ def chat_room_info(room_id):
     if not (is_member or is_public or is_admin):
         abort(403)
 
-    return render_template('chat_info.html', room=room)
+    # Fetch recent media
+    media_messages = ChatMessage.query.filter(
+        ChatMessage.room_id == room_id,
+        ChatMessage.file_path.isnot(None)
+    ).order_by(ChatMessage.timestamp.desc()).limit(10).all()
+
+    return render_template('chat_info.html', room=room, media_messages=media_messages)
 
 @main.route('/chat/upload', methods=['POST'])
 @login_required

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}E-Learning Platform{% endblock %}</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css">
     {% block styles %}{% endblock %}
 </head>
 <body>

--- a/templates/chat_info.html
+++ b/templates/chat_info.html
@@ -2,43 +2,292 @@
 
 {% block title %}{{ room.name }} - Info{% endblock %}
 
+{% block styles %}
+<style>
+    body, html {
+        background-color: #14191D !important;
+        color: #FFFFFF;
+        font-family: 'Poppins', sans-serif;
+    }
+    .info-page-container {
+        padding-bottom: 2rem;
+    }
+    .info-header {
+        display: flex;
+        align-items: center;
+        padding: 1rem;
+        background-color: #1F262D;
+        position: sticky;
+        top: 0;
+        z-index: 10;
+    }
+    .info-header .back-arrow {
+        color: white;
+        font-size: 1.5rem;
+        text-decoration: none;
+        margin-right: 1rem;
+    }
+    .info-header h1 {
+        margin: 0;
+        font-size: 1.2rem;
+    }
+    .info-top-section {
+        text-align: center;
+        padding: 2rem 1rem;
+    }
+    .info-avatar-large {
+        width: 150px;
+        height: 150px;
+        border-radius: 50%;
+        background-color: #002D62;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-weight: bold;
+        font-size: 4rem;
+        color: white;
+        border: 3px solid white;
+        margin-bottom: 1rem;
+    }
+    .info-avatar-large img {
+        width: 100%;
+        height: 100%;
+        border-radius: 50%;
+        object-fit: cover;
+    }
+    .info-top-section h2 {
+        font-weight: bold;
+        margin-bottom: 0.5rem;
+    }
+    .room-description {
+        color: #B0B0B0;
+        font-size: 0.9rem;
+        margin-bottom: 1rem;
+    }
+    .members-count {
+        color: #B0B0B0;
+        font-size: 0.9rem;
+        text-align: left;
+        padding: 0 1rem;
+    }
+    .info-section {
+        background-color: #1F262D;
+        margin: 1rem 0;
+        padding: 1rem;
+        border-radius: 10px;
+    }
+    .info-section h3 {
+        margin-top: 0;
+        margin-bottom: 1rem;
+        font-size: 1rem;
+        font-weight: normal;
+        color: #007BFF;
+    }
+    .members-list {
+        list-style: none;
+        padding: 0;
+    }
+    .members-list li {
+        display: flex;
+        align-items: center;
+        padding: 0.75rem 0;
+        border-bottom: 1px solid #444;
+        cursor: pointer;
+        transition: background-color 0.2s;
+    }
+    .members-list li:last-child {
+        border-bottom: none;
+    }
+    .members-list li:hover {
+        background-color: #2A343D;
+    }
+    .member-avatar {
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        background-color: #002D62;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-weight: bold;
+        color: white;
+        margin-right: 1rem;
+    }
+    .member-avatar img {
+        width: 100%;
+        height: 100%;
+        border-radius: 50%;
+        object-fit: cover;
+    }
+    .member-info {
+        display: flex;
+        flex-direction: column;
+    }
+    .member-name {
+        font-weight: bold;
+    }
+    .member-role {
+        font-size: 0.8rem;
+        color: #B0B0B0;
+    }
+    .media-scroller {
+        display: flex;
+        gap: 10px;
+        overflow-x: auto;
+        padding-bottom: 10px;
+    }
+    .media-item {
+        flex: 0 0 100px;
+        height: 100px;
+        background-color: #444;
+        border-radius: 5px;
+        overflow: hidden;
+        position: relative;
+    }
+    .media-item img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+    }
+    .file-placeholder {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        width: 100%;
+        height: 100%;
+        text-align: center;
+        padding: 5px;
+    }
+    .file-placeholder i {
+        font-size: 2rem;
+        margin-bottom: 5px;
+    }
+    .file-placeholder span {
+        font-size: 0.7rem;
+        word-break: break-all;
+    }
+    .mute-section {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+    }
+    .switch {
+        position: relative;
+        display: inline-block;
+        width: 50px;
+        height: 28px;
+    }
+    .switch input {
+        opacity: 0;
+        width: 0;
+        height: 0;
+    }
+    .slider {
+        position: absolute;
+        cursor: pointer;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background-color: #ccc;
+        transition: .4s;
+    }
+    .slider:before {
+        position: absolute;
+        content: "";
+        height: 20px;
+        width: 20px;
+        left: 4px;
+        bottom: 4px;
+        background-color: white;
+        transition: .4s;
+    }
+    input:checked + .slider {
+        background-color: #007BFF;
+    }
+    input:checked + .slider:before {
+        transform: translateX(22px);
+    }
+    .slider.round {
+        border-radius: 28px;
+    }
+    .slider.round:before {
+        border-radius: 50%;
+    }
+</style>
+{% endblock %}
+
 {% block content %}
-<div class="container mt-4">
-    <div class="card">
-        {% if room.cover_image %}
-            <img src="{{ url_for('static', filename=room.cover_image) }}" class="card-img-top" alt="Room Cover Image" style="max-height: 300px; object-fit: cover;">
-        {% endif %}
-        <div class="card-header">
-            <h3>Room Information</h3>
-        </div>
-        <div class="card-body">
-            <h5 class="card-title">{{ room.name }}</h5>
-            <p class="card-text">{{ room.description or 'No description available.' }}</p>
-            <ul class="list-group list-group-flush">
-                <li class="list-group-item"><strong>Type:</strong> {{ room.room_type | capitalize }}</li>
-                <li class="list-group-item"><strong>Created by:</strong> {{ room.creator.name if room.creator else 'System' }}</li>
-                <li class="list-group-item"><strong>Created at:</strong> {{ room.created_at.strftime('%Y-%m-%d') }}</li>
-                <li class="list-group-item"><strong>Speech-to-Text Enabled:</strong> {% if room.speech_enabled %}Yes{% else %}No{% endif %}</li>
-            </ul>
-        </div>
+<div class="info-page-container">
+    <div class="info-header">
+        <a href="{{ url_for('main.chat_room', room_id=room.id) }}" class="back-arrow">&larr;</a>
+        <h1>Group Info</h1>
     </div>
 
-    <div class="card mt-4">
-        <div class="card-header">
-            <h3>Members ({{ room.members.count() }})</h3>
-        </div>
-        <ul class="list-group list-group-flush">
-            {% for member in room.members %}
-            <li class="list-group-item d-flex justify-content-between align-items-center">
-                <a href="{{ url_for('main.view_user', user_id=member.user.id) }}">{{ member.user.name }}</a>
-                <span class="badge bg-primary rounded-pill">{{ member.user.role }}</span>
-            </li>
+    <div class="info-top-section">
+        <div class="info-avatar-large">
+            {% if room.cover_image %}
+                <img src="{{ url_for('static', filename=room.cover_image) }}" alt="{{ room.name }}">
             {% else %}
-            <li class="list-group-item">This room has no members.</li>
+                <span>{{ room.name[0] | upper }}</span>
+            {% endif %}
+        </div>
+        <h2>{{ room.name }}</h2>
+        <p class="room-description">{{ room.description or 'No description available.' }}</p>
+    </div>
+
+    <div class="info-section">
+        <p class="members-count">{{ room.members.count() }} participants</p>
+    </div>
+
+    <div class="info-section members-list-section">
+        <h3>Members</h3>
+        <ul class="members-list">
+            {% for member in room.members %}
+            <li>
+                <div class="member-avatar">
+                    {% if member.user.profile_pic %}
+                        <img src="{{ url_for('static', filename='profile_pics/' + member.user.profile_pic) }}" alt="{{ member.user.name }}">
+                    {% else %}
+                        <span>{{ member.user.name[0] | upper }}</span>
+                    {% endif %}
+                </div>
+                <div class="member-info">
+                    <span class="member-name">{{ member.user.name }}</span>
+                    <span class="member-role">{{ member.role_in_room | capitalize }}</span>
+                </div>
+            </li>
             {% endfor %}
         </ul>
     </div>
 
-    <a href="{{ url_for('main.chat_room', room_id=room.id) }}" class="btn btn-secondary mt-3">Back to Chat</a>
+    <div class="info-section media-section">
+        <h3>Media, Links & Docs</h3>
+        <div class="media-scroller">
+            {% for message in media_messages %}
+                <a href="{{ url_for('static', filename=message.file_path) }}" target="_blank" class="media-item">
+                    {% if message.file_name.lower().endswith(('.png', '.jpg', '.jpeg', '.gif')) %}
+                        <img src="{{ url_for('static', filename=message.file_path) }}" alt="Media">
+                    {% else %}
+                        <div class="file-placeholder">
+                            <i class="fas fa-file-alt"></i>
+                            <span>{{ message.file_name }}</span>
+                        </div>
+                    {% endif %}
+                </a>
+            {% else %}
+                <p>No media has been shared in this room yet.</p>
+            {% endfor %}
+        </div>
+    </div>
+
+    <div class="info-section mute-section">
+        <span>Mute Notifications</span>
+        <label class="switch">
+            <input type="checkbox">
+            <span class="slider round"></span>
+        </label>
+    </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
This commit completely redesigns the Group Info page to match a more modern, WhatsApp-style layout and the app's existing dark theme.

The new design includes the following sections and features:
- A redesigned header with a large, centered, circular group profile picture, name, and description.
- A members list with individual profile pictures and roles.
- A new section to display recent media, links, and documents shared in the group.
- A UI-only mute notifications toggle.

The styling has been updated to use the app's dark theme, with a dark blue-black background and white/light gray text for readability.

The `chat_room_info` route has been updated to fetch recent media messages to populate the new media section.