### PR TITLE
fix: Remove footer from chat page

### DIFF
--- a/templates/chat.html
+++ b/templates/chat.html
@@ -4,6 +4,9 @@
 
 {% block styles %}
 <style>
+    footer {
+        display: none;
+    }
     body, html {
         height: 100%;
         margin: 0;


### PR DESCRIPTION
This commit removes the footer from the chat page to provide a more immersive and focused chat experience.

The footer is hidden by adding a CSS rule to the `chat.html` template to set its display to `none`. This change only affects the chat page and the footer remains visible on all other pages.