### PR TITLE
feat: Implement 'Create Group' functionality

### DIFF
--- a/templates/chat_list.html
+++ b/templates/chat_list.html
@@ -130,6 +130,26 @@
         font-weight: bold;
         font-size: 0.8rem;
     }
+    .create-group-btn {
+        position: fixed;
+        bottom: 20px;
+        right: 20px;
+        width: 60px;
+        height: 60px;
+        background-color: #007BFF;
+        color: white;
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 2rem;
+        text-decoration: none;
+        box-shadow: 0 4px 8px rgba(0,0,0,0.2);
+        transition: background-color 0.3s;
+    }
+    .create-group-btn:hover {
+        background-color: #0056b3;
+    }
 </style>
 {% endblock %}
 
@@ -168,6 +188,8 @@
         <p>You don't have access to any chat rooms yet.</p>
         {% endfor %}
     </ul>
+
+    <a href="{{ url_for('main.create_group') }}" class="create-group-btn">+</a>
 </div>
 {% endblock %}
 

--- a/templates/create_group.html
+++ b/templates/create_group.html
@@ -1,0 +1,135 @@
+{% extends "base.html" %}
+
+{% block title %}Create New Group{% endblock %}
+
+{% block styles %}
+<style>
+    .form-container {
+        max-width: 600px;
+        margin: 2rem auto;
+        padding: 2rem;
+        background-color: #1F262D;
+        border-radius: 10px;
+        color: white;
+    }
+    .form-group {
+        margin-bottom: 1.5rem;
+    }
+    .form-group label {
+        display: block;
+        margin-bottom: 0.5rem;
+        font-weight: bold;
+    }
+    .form-group input[type="text"],
+    .form-group textarea {
+        width: 100%;
+        padding: 0.75rem;
+        border-radius: 5px;
+        border: 1px solid #808080;
+        background-color: #2A343D;
+        color: white;
+    }
+    .form-group textarea {
+        resize: vertical;
+    }
+    .form-group .radio-group {
+        display: flex;
+        gap: 1rem;
+    }
+    .btn-submit {
+        width: 100%;
+        padding: 0.75rem;
+        border: none;
+        border-radius: 5px;
+        background-color: #007BFF;
+        color: white;
+        font-size: 1rem;
+        font-weight: bold;
+        cursor: pointer;
+        transition: background-color 0.3s;
+    }
+    .btn-submit:hover {
+        background-color: #0056b3;
+    }
+    .user-list {
+        max-height: 200px;
+        overflow-y: auto;
+        border: 1px solid #808080;
+        border-radius: 5px;
+        padding: 0.5rem;
+        margin-top: 0.5rem;
+    }
+    .user-item {
+        display: flex;
+        align-items: center;
+        padding: 0.5rem;
+    }
+    .user-item:hover {
+        background-color: #2A343D;
+    }
+    .user-item input[type="checkbox"] {
+        margin-right: 0.5rem;
+    }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="form-container">
+    <h2>Create New Group</h2>
+    <form action="{{ url_for('main.create_group') }}" method="POST" enctype="multipart/form-data">
+        <div class="form-group">
+            <label for="group_name">Group Name</label>
+            <input type="text" id="group_name" name="group_name" required>
+        </div>
+        <div class="form-group">
+            <label for="group_description">Group Description</label>
+            <textarea id="group_description" name="group_description" rows="3"></textarea>
+        </div>
+        <div class="form-group">
+            <label for="group_icon">Group Icon</label>
+            <input type="file" id="group_icon" name="group_icon" accept="image/*">
+        </div>
+        <div class="form-group">
+            <label>Group Type</label>
+            <div class="radio-group">
+                <label>
+                    <input type="radio" name="group_type" value="public" checked> Public
+                </label>
+                <label>
+                    <input type="radio" name="group_type" value="private"> Private
+                </label>
+            </div>
+        </div>
+        <div class="form-group">
+            <label>Add Members</label>
+            <input type="text" id="member-search" placeholder="Search for users...">
+            <div class="user-list">
+                {% for user in users %}
+                <div class="user-item">
+                    <input type="checkbox" name="members" value="{{ user.id }}" id="user-{{ user.id }}">
+                    <label for="user-{{ user.id }}">{{ user.name }}</label>
+                </div>
+                {% endfor %}
+            </div>
+        </div>
+        <button type="submit" class="btn-submit">Create Group</button>
+    </form>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+    document.getElementById('member-search').addEventListener('keyup', function() {
+        let filter = this.value.toLowerCase();
+        let users = document.querySelectorAll('.user-item');
+        users.forEach(user => {
+            let label = user.querySelector('label');
+            if (label.textContent.toLowerCase().includes(filter)) {
+                user.style.display = '';
+            } else {
+                user.style.display = 'none';
+            }
+        });
+    });
+</script>
+{% endblock %}


### PR DESCRIPTION
This commit introduces the first phase of the new WhatsApp-style group management system: the ability to create new groups.

Key features in this commit:
- A floating '+' button has been added to the chat list page, providing an entry point to the group creation process.
- A new 'Create New Group' page has been created with a form that includes fields for group name, description, icon, and type (public/private).
- A searchable list of registered users with checkboxes has been added to the form, allowing the group creator to add members upon creation.
- Backend routes have been implemented to render the form and handle the form submission. The form handling logic creates the new chat room, assigns the creator as an admin, and adds the selected members to the group.

This commit lays the foundation for the new group management system. The next phases will include features for managing existing groups.