### PR TITLE
feat: Implement 'Manage Group Info' features for admins

### DIFF
--- a/chat_events.py
+++ b/chat_events.py
@@ -231,3 +231,33 @@ def register_chat_events(socketio):
             'room_id': message.room_id,
             'reactions': reactions_data
         }, to=message.room_id)
+
+    @socketio.on('remove_member')
+    def remove_member(data):
+        if not current_user.is_authenticated:
+            return
+
+        room_id = data.get('room_id')
+        user_id = data.get('user_id')
+
+        room = ChatRoom.query.get(room_id)
+        if not room:
+            return
+
+        # Authorization check
+        user_membership = ChatRoomMember.query.filter_by(
+            user_id=current_user.id,
+            chat_room_id=room_id
+        ).first()
+        if not user_membership or user_membership.role_in_room != 'admin':
+            return
+
+        member_to_remove = ChatRoomMember.query.filter_by(
+            user_id=user_id,
+            chat_room_id=room_id
+        ).first()
+
+        if member_to_remove:
+            db.session.delete(member_to_remove)
+            db.session.commit()
+            emit('member_removed', {'user_id': user_id, 'room_id': room_id}, to=room_id)

--- a/templates/add_members.html
+++ b/templates/add_members.html
@@ -1,0 +1,97 @@
+{% extends "base.html" %}
+
+{% block title %}Add Members to {{ room.name }}{% endblock %}
+
+{% block styles %}
+<style>
+    .form-container {
+        max-width: 600px;
+        margin: 2rem auto;
+        padding: 2rem;
+        background-color: #1F262D;
+        border-radius: 10px;
+        color: white;
+    }
+    .form-group {
+        margin-bottom: 1.5rem;
+    }
+    .form-group label {
+        display: block;
+        margin-bottom: 0.5rem;
+        font-weight: bold;
+    }
+    .user-list {
+        max-height: 300px;
+        overflow-y: auto;
+        border: 1px solid #808080;
+        border-radius: 5px;
+        padding: 0.5rem;
+        margin-top: 0.5rem;
+    }
+    .user-item {
+        display: flex;
+        align-items: center;
+        padding: 0.5rem;
+    }
+    .user-item:hover {
+        background-color: #2A343D;
+    }
+    .user-item input[type="checkbox"] {
+        margin-right: 0.5rem;
+    }
+    .btn-submit {
+        width: 100%;
+        padding: 0.75rem;
+        border: none;
+        border-radius: 5px;
+        background-color: #007BFF;
+        color: white;
+        font-size: 1rem;
+        font-weight: bold;
+        cursor: pointer;
+        transition: background-color 0.3s;
+        margin-top: 1rem;
+    }
+    .btn-submit:hover {
+        background-color: #0056b3;
+    }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="form-container">
+    <h2>Add Members to {{ room.name }}</h2>
+    <form action="{{ url_for('main.add_members', room_id=room.id) }}" method="POST">
+        <div class="form-group">
+            <label>Select users to add</label>
+            <input type="text" id="member-search" placeholder="Search for users...">
+            <div class="user-list">
+                {% for user in users %}
+                <div class="user-item">
+                    <input type="checkbox" name="members" value="{{ user.id }}" id="user-{{ user.id }}">
+                    <label for="user-{{ user.id }}">{{ user.name }}</label>
+                </div>
+                {% endfor %}
+            </div>
+        </div>
+        <button type="submit" class="btn-submit">Add Selected Members</button>
+    </form>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+    document.getElementById('member-search').addEventListener('keyup', function() {
+        let filter = this.value.toLowerCase();
+        let users = document.querySelectorAll('.user-item');
+        users.forEach(user => {
+            let label = user.querySelector('label');
+            if (label.textContent.toLowerCase().includes(filter)) {
+                user.style.display = '';
+            } else {
+                user.style.display = 'none';
+            }
+        });
+    });
+</script>
+{% endblock %}

--- a/templates/chat_info.html
+++ b/templates/chat_info.html
@@ -39,6 +39,7 @@
         padding: 2rem 1rem;
     }
     .info-avatar-large {
+        position: relative;
         width: 150px;
         height: 150px;
         border-radius: 50%;
@@ -51,6 +52,22 @@
         color: white;
         border: 3px solid white;
         margin-bottom: 1rem;
+    }
+    .camera-icon {
+        position: absolute;
+        bottom: 5px;
+        right: 5px;
+        width: 40px;
+        height: 40px;
+        background-color: #007BFF;
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: white;
+        font-size: 1.5rem;
+        cursor: pointer;
+        border: 2px solid white;
     }
     .info-avatar-large img {
         width: 100%;
@@ -235,6 +252,11 @@
             {% else %}
                 <span>{{ room.name[0] | upper }}</span>
             {% endif %}
+            {% if user_role_in_room == 'admin' %}
+                <a href="{{ url_for('main.edit_group_icon', room_id=room.id) }}" class="camera-icon">
+                    <i class="fas fa-camera"></i>
+                </a>
+            {% endif %}
         </div>
         <h2>{{ room.name }}</h2>
         <p class="room-description">{{ room.description or 'No description available.' }}</p>
@@ -245,21 +267,31 @@
     </div>
 
     <div class="info-section members-list-section">
-        <h3>Members</h3>
+        <div class="d-flex justify-content-between align-items-center">
+            <h3>Members</h3>
+            {% if user_role_in_room == 'admin' %}
+                <a href="{{ url_for('main.add_members', room_id=room.id) }}" class="btn btn-primary btn-sm">Add Member</a>
+            {% endif %}
+        </div>
         <ul class="members-list">
             {% for member in room.members %}
-            <li>
-                <div class="member-avatar">
-                    {% if member.user.profile_pic %}
-                        <img src="{{ url_for('static', filename='profile_pics/' + member.user.profile_pic) }}" alt="{{ member.user.name }}">
-                    {% else %}
-                        <span>{{ member.user.name[0] | upper }}</span>
-                    {% endif %}
+            <li class="d-flex justify-content-between align-items-center">
+                <div class="d-flex align-items-center">
+                    <div class="member-avatar">
+                        {% if member.user.profile_pic %}
+                            <img src="{{ url_for('static', filename='profile_pics/' + member.user.profile_pic) }}" alt="{{ member.user.name }}">
+                        {% else %}
+                            <span>{{ member.user.name[0] | upper }}</span>
+                        {% endif %}
+                    </div>
+                    <div class="member-info">
+                        <span class="member-name">{{ member.user.name }}</span>
+                        <span class="member-role">{{ member.role_in_room | capitalize }}</span>
+                    </div>
                 </div>
-                <div class="member-info">
-                    <span class="member-name">{{ member.user.name }}</span>
-                    <span class="member-role">{{ member.role_in_room | capitalize }}</span>
-                </div>
+                {% if user_role_in_room == 'admin' and member.user_id != current_user.id %}
+                    <button class="btn btn-danger btn-sm remove-member-btn" data-member-id="{{ member.user.id }}">Remove</button>
+                {% endif %}
             </li>
             {% endfor %}
         </ul>

--- a/templates/edit_group_icon.html
+++ b/templates/edit_group_icon.html
@@ -1,0 +1,78 @@
+{% extends "base.html" %}
+
+{% block title %}Edit Group Icon{% endblock %}
+
+{% block styles %}
+<style>
+    .form-container {
+        max-width: 600px;
+        margin: 2rem auto;
+        padding: 2rem;
+        background-color: #1F262D;
+        border-radius: 10px;
+        color: white;
+        text-align: center;
+    }
+    .preview-container {
+        width: 200px;
+        height: 200px;
+        border-radius: 50%;
+        border: 3px solid #007BFF;
+        margin: 1rem auto;
+        overflow: hidden;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+    .preview-container img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+    }
+    .btn-submit {
+        width: 100%;
+        padding: 0.75rem;
+        border: none;
+        border-radius: 5px;
+        background-color: #007BFF;
+        color: white;
+        font-size: 1rem;
+        font-weight: bold;
+        cursor: pointer;
+        transition: background-color 0.3s;
+        margin-top: 1rem;
+    }
+    .btn-submit:hover {
+        background-color: #0056b3;
+    }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="form-container">
+    <h2>Change Group Icon</h2>
+    <form action="{{ url_for('main.edit_group_icon', room_id=room.id) }}" method="POST" enctype="multipart/form-data">
+        <div class="preview-container">
+            <img id="image-preview" src="{{ url_for('static', filename=room.cover_image or 'images/course_placeholder.jpg') }}" alt="Group Icon Preview">
+        </div>
+        <div class="form-group">
+            <label for="group_icon">Select new icon</label>
+            <input type="file" id="group_icon" name="group_icon" accept="image/*" required onchange="previewImage(event)">
+        </div>
+        <button type="submit" class="btn-submit">Save Changes</button>
+    </form>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+    function previewImage(event) {
+        var reader = new FileReader();
+        reader.onload = function(){
+            var output = document.getElementById('image-preview');
+            output.src = reader.result;
+        };
+        reader.readAsDataURL(event.target.files[0]);
+    }
+</script>
+{% endblock %}


### PR DESCRIPTION
This commit introduces the second phase of the new WhatsApp-style group management system: the ability for admins to manage existing groups.

Key features in this commit:
- Admin-only controls have been added to the Group Info page (`chat_info.html`).
- Admins can now change the group display picture via a new 'Edit Group Icon' page.
- Admins can add new members to a group via a new 'Add Members' page.
- Admins can remove existing members from a group.
- The backend has been updated with new routes and Socket.IO events to support these features.

This commit builds on the 'Create Group' feature and provides admins with the necessary tools to manage their groups effectively.