### PR TITLE
I've fixed an `IndentationError` in `chat_events.py` that was causing…

### DIFF
--- a/chat_events.py
+++ b/chat_events.py
@@ -81,7 +81,7 @@ def register_chat_events(socketio):
                 can_send = False
                 if room.room_type == 'general' and current_user.role == 'admin':
                     can_send = True
-            elif room.room_type == 'course' and (current_user.role == 'admin' or (room.course_room and current_user.id == room.course_room.instructor_id)):
+                elif room.room_type == 'course' and (current_user.role == 'admin' or (room.course_room and current_user.id == room.course_room.instructor_id)):
                     can_send = True
 
                 if not can_send:


### PR DESCRIPTION
… your application to crash on startup. The error was due to incorrect indentation in a `try...except` block. I've corrected it, so your chat functionality should now be restored.