### PR TITLE
fix: Resolve Internal Server Error on student dashboard

### DIFF
--- a/models.py
+++ b/models.py
@@ -284,7 +284,7 @@ class ChatRoomMember(db.Model):
     chat_room_id = db.Column(db.Integer, db.ForeignKey('chat_room.id'), nullable=False)
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
     role_in_room = db.Column(db.String(50), nullable=False, default='member') # e.g., member, admin
-    user = db.relationship('User')
+    user = db.relationship('User', backref=db.backref('chat_memberships', lazy='dynamic'))
     __table_args__ = (db.UniqueConstraint('chat_room_id', 'user_id', name='_room_user_uc'),)
 
 

--- a/routes.py
+++ b/routes.py
@@ -1082,7 +1082,9 @@ def student_dashboard():
 
     # Unread Messages Count
     unread_messages_count = 0
-    member_room_ids = [m.chat_room_id for m in current_user.chat_memberships]
+    # Querying ChatRoomMember directly is more robust than relying on the backref
+    memberships = ChatRoomMember.query.filter_by(user_id=current_user.id).all()
+    member_room_ids = [m.chat_room_id for m in memberships]
     for room_id in member_room_ids:
         last_read = UserLastRead.query.filter_by(user_id=current_user.id, room_id=room_id).first()
         last_read_time = last_read.last_read_timestamp if last_read else datetime.min


### PR DESCRIPTION
This commit fixes a 500 Internal Server Error that occurred when loading the student dashboard.

The error was caused by an issue in the logic for calculating the number of unread chat messages. The original implementation relied on a back-reference from the `User` model that was causing an error.

The fix replaces this with a more direct and robust query to the `ChatRoomMember` model to retrieve the user's chat room memberships, ensuring the unread message count is calculated correctly and preventing the server error.