### PR TITLE
refine: Add slide-out animation to mobile navigation menu

### DIFF
--- a/static/css/home.css
+++ b/static/css/home.css
@@ -95,6 +95,8 @@ header {
     display: flex;
     gap: 25px;
     align-items: center;
+    max-height: none;
+    overflow: visible;
 }
 
 .nav-links a {
@@ -866,16 +868,20 @@ body:has(.custom-footer) > footer {
         display: block; /* Show hamburger on mobile */
     }
     .nav-links {
-        display: none; /* Hide nav links by default */
         flex-direction: column;
         width: 100%;
         text-align: center;
         background-color: rgba(255, 255, 255, 0.98);
-        padding: 20px 0;
         border-top: 1px solid #EDEFF2;
+        overflow: hidden;
+        max-height: 0;
+        transition: max-height 0.5s ease-out, padding 0.5s ease-out;
+        padding: 0; /* No padding when closed */
     }
     .nav-links.active {
-        display: flex; /* Show nav links when active */
+        display: flex;
+        max-height: 500px; /* Animate to a height large enough for content */
+        padding: 20px 0; /* Add padding back when open */
     }
     .nav-links a {
         padding: 15px 0;


### PR DESCRIPTION
This commit refines the responsive navigation by adding a smooth slide-out animation to the hamburger menu on mobile and tablet views.

The implementation changes the CSS from a `display: none` toggle to a `max-height` transition, providing a better user experience as requested by the user.