### PR TITLE
Fix broken migration and Flask CLI command discovery

### DIFF
--- a/app.py
+++ b/app.py
@@ -125,6 +125,8 @@ def create_app(config_object=None):
 
     return app
 
+# Create a default app instance for discoverability by Flask CLI
+app = create_app()
+
 if __name__ == '__main__':
-    app = create_app()
     socketio.run(app, debug=True, allow_unsafe_werkzeug=True)


### PR DESCRIPTION
This commit addresses two issues:

1.  The migration in `da444f06d509_add_is_published_to_finalexam.py` was incorrectly generated and attempted to create the entire database schema, causing an `OperationalError`. This has been corrected to only add the `is_published` column to the `final_exam` table as originally intended.

2.  Flask CLI commands such as `db` and `create-admin` were not discoverable because the Flask app instance was not exposed globally. `app.py` has been modified to create a default app instance, making it discoverable by the `flask` command-line tool.